### PR TITLE
feat: add condition to skip Prisma validation and GitGuardian scan for dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,13 @@ jobs:
         run: npm run lint
 
       - name: Prisma Validate
+        if: ${{ github.actor != 'dependabot[bot]' }}
         run: npx prisma validate
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
       - name: GitGuardian Scan
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: GitGuardian/ggshield/actions/secret@v1.43.0
         env:
           GITHUB_PUSH_BASE_SHA: ${{ github.event.base }}


### PR DESCRIPTION
## Closes: #254 

## Type of change

- New feature (non-breaking change which adds functionality)

## Summary

Skipped dependabot to run the prisma schema validate and git-guardian section of the ci.yml.

## Checklist

- [x] Closes linked issue number
- [x] Ran `npm run build` locally without errors
- [x] Database changes (if any) have associated Prisma migration
- [x] Updated documentation (README / comments / md files)
- [x] No sensitive info committed