### PR TITLE
fix: add .prettierignore file to exclude build outputs, dependencies, and lockfiles

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+# Build outputs
+dist
+.next
+build
+coverage
+
+# Dependencies
+node_modules
+
+# Lockfiles
+yarn.lock
+pnpm-lock.yaml
+package-lock.json


### PR DESCRIPTION
## Closes: #354 

## Type of change

- [ ] Chore
- [x] Bug fix
- [ ] Refactor
- [ ] New feature
- [ ] Performance
- [ ] Documentation
- [ ] Breaking change

## Summary
Fixed prettier check on ci workflow run.

## Checklist

- [x] Issue linked
- [ ] Documentation updated
- [x] No sensitive data committed
- [ ] Prisma migration added (if schema changed)
