### PR TITLE
feat: Enhance UI components and add new functionality for booklets

### DIFF
--- a/src/actions/booklets.ts
+++ b/src/actions/booklets.ts
@@ -763,3 +763,48 @@ export const recalculateAllBookletStatuses = async (): Promise<Result<{ updated:
 		return failure(databaseError("Failed to recalculate booklet statuses"));
 	}
 };
+
+export const updateBookletAnchorCoordinates = async (
+	bookletId: string,
+	anchorX: number,
+	anchorY: number
+): Promise<Result<BookletItem, DatabaseError | ValidationError>> => {
+	try {
+		const booklet = await prisma.concessionBooklet.findUnique({
+			where: { id: bookletId }
+		});
+
+		if (!booklet) {
+			return failure(validationError("Booklet not found"));
+		}
+
+		if (anchorX < 0 || anchorX > 100) {
+			return failure(validationError("Anchor X must be between 0 and 100"));
+		}
+
+		if (anchorY < 0 || anchorY > 100) {
+			return failure(validationError("Anchor Y must be between 0 and 100"));
+		}
+
+		const updatedBooklet = await prisma.concessionBooklet.update({
+			where: { id: bookletId },
+			data: {
+				anchorX,
+				anchorY
+			},
+			include: {
+				_count: {
+					select: {
+						applications: true
+					}
+				}
+			}
+		});
+
+		revalidatePath("/dashboard/admin/booklets");
+		return success(updatedBooklet);
+	} catch (error) {
+		console.error("Error updating booklet anchor coordinates:", error);
+		return failure(databaseError("Failed to update anchor coordinates"));
+	}
+};

--- a/src/actions/generate-sample-overlay-pdf.ts
+++ b/src/actions/generate-sample-overlay-pdf.ts
@@ -1,0 +1,181 @@
+"use server";
+
+import { Result, success, failure, authError, AuthError, databaseError, DatabaseError } from "@/lib/result";
+import jsPDF from "jspdf";
+import prisma from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+import { headers } from "next/headers";
+import { PDFDocument, degrees } from "pdf-lib";
+
+type FormLayout = {
+	left: Record<string, { x: number; y: number }>;
+	right: Record<string, { x: number; y: number }>;
+};
+
+const formatDate = (date: Date) => {
+	const d = new Date(date);
+	const day = d.getDate().toString().padStart(2, "0");
+	const month = (d.getMonth() + 1).toString().padStart(2, "0");
+	const year = d.getFullYear();
+	return `${day}/${month}/${year}`;
+};
+
+const formatDateMonthOnly = (date: Date) => {
+	const d = new Date(date);
+	const day = d.getDate().toString().padStart(2, "0");
+	const month = (d.getMonth() + 1).toString().padStart(2, "0");
+	return `${day}/${month}/`;
+};
+
+const formatYearLastTwoDigits = (date: Date) => {
+	const d = new Date(date);
+	const year = d.getFullYear();
+	return String(year).slice(-2);
+};
+
+const addMonths = (date: Date, months: number) => {
+	const d = new Date(date);
+	const originalDay = d.getDate();
+	d.setMonth(d.getMonth() + months);
+	if (d.getDate() !== originalDay) d.setDate(0);
+	return d;
+};
+
+const calcAge = (dob: Date) => {
+	const today = new Date();
+	const birth = new Date(dob);
+	let years = today.getFullYear() - birth.getFullYear();
+	let months = today.getMonth() - birth.getMonth();
+	if (today.getDate() < birth.getDate()) months--;
+	if (months < 0) {
+		years--;
+		months += 12;
+	}
+	return { years, months };
+};
+
+const SAMPLE_DATA = {
+	gender: "Male",
+	classCode: "II",
+	periodDuration: 3,
+	toStation: "Kurla",
+	lastName: "Sharma",
+	firstName: "Rajesh",
+	middleName: "Kumar",
+	className: "Second",
+	stationName: "Thane",
+	periodName: "Quarterly",
+	dateOfBirth: new Date(2003, 2, 15),
+	previousCertificateNumber: "A0807550",
+	previousApplicationDate: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000),
+	address: "B-204, Hiranandani Estate, Ghodbunder Road, Thane West, Thane 400607"
+};
+
+export const generateSampleOverlayPDF = async (
+	anchorX: number,
+	anchorY: number
+): Promise<Result<string, AuthError | DatabaseError>> => {
+	try {
+		const session = await auth.api.getSession({
+			headers: await headers()
+		});
+
+		if (!session?.user?.id) {
+			return failure(authError("Authentication required", "UNAUTHORIZED"));
+		}
+
+		const admin = await prisma.admin.findUnique({
+			where: { userId: session.user.id }
+		});
+
+		if (!admin) {
+			return failure(authError("Admin access required", "FORBIDDEN"));
+		}
+
+		const config = await prisma.appConfig.findUnique({
+			where: { key: "form_layout" }
+		});
+		if (!config) return failure(databaseError("Form layout configuration not found"));
+
+		const now = new Date();
+		const layout = config.value as FormLayout;
+		const age = calcAge(SAMPLE_DATA.dateOfBirth);
+
+		const eff = (pt?: { x: number; y: number }) => (pt ? { x: anchorX + pt.x, y: anchorY + pt.y } : undefined);
+
+		const doc = new jsPDF({
+			unit: "pt",
+			format: [842, 666.14],
+			orientation: "landscape"
+		});
+
+		doc.setFont("times");
+		doc.setFontSize(12);
+
+		const writeText = (pt: { x: number; y: number } | undefined, text: string) => {
+			if (!pt || !text) return;
+			const yOffset = text === "-" ? pt.y - 5 : pt.y;
+			doc.text(text, pt.x, yOffset);
+		};
+
+		const writeMultilineText = (pt: { x: number; y: number } | undefined, text: string, maxWidth: number = 50) => {
+			if (!pt || !text) return;
+			const lines = doc.splitTextToSize(text, maxWidth);
+			doc.text(lines, pt.x, pt.y);
+		};
+
+		const fullName = `${SAMPLE_DATA.firstName} ${SAMPLE_DATA.middleName} ${SAMPLE_DATA.lastName}`;
+
+		writeText(eff(layout.left.gender), SAMPLE_DATA.gender);
+		writeText(eff(layout.left.student_name_left), fullName);
+		writeText(eff(layout.left.class_left), SAMPLE_DATA.className);
+		writeText(eff(layout.left.period_left), SAMPLE_DATA.periodName);
+		writeMultilineText(eff(layout.left.from_station_left), SAMPLE_DATA.stationName);
+		writeText(eff(layout.left.to_station_left), SAMPLE_DATA.toStation);
+
+		writeText(eff(layout.left.previous_certificate_number), SAMPLE_DATA.previousCertificateNumber);
+
+		const prevEnd = addMonths(SAMPLE_DATA.previousApplicationDate, SAMPLE_DATA.periodDuration);
+		writeText(eff(layout.left.last_season_ticket_held_upto_date), formatDateMonthOnly(prevEnd));
+		writeText(eff(layout.left.last_season_ticket_held_upto_year), formatYearLastTwoDigits(prevEnd));
+
+		writeText(eff(layout.left.date_of_issue_left), formatDate(now));
+
+		writeText(eff(layout.right.student_name_right), fullName);
+		writeText(eff(layout.right.age_years), String(age.years));
+		writeText(eff(layout.right.age_months), String(age.months));
+		writeText(eff(layout.right.date_of_birth), formatDate(SAMPLE_DATA.dateOfBirth));
+		writeText(eff(layout.right.class_right), SAMPLE_DATA.className);
+		writeText(eff(layout.right.period_right), SAMPLE_DATA.periodName);
+		writeMultilineText(eff(layout.right.from_station_right), SAMPLE_DATA.stationName);
+		writeText(eff(layout.right.to_station_right), SAMPLE_DATA.toStation);
+
+		writeText(eff(layout.right.current_pass_class), SAMPLE_DATA.classCode);
+		writeText(eff(layout.right.current_pass_season_ticket_number), SAMPLE_DATA.previousCertificateNumber);
+		writeText(eff(layout.right.current_pass_from_station), SAMPLE_DATA.stationName);
+		writeText(eff(layout.right.current_pass_to_station), SAMPLE_DATA.toStation);
+
+		const prevStart = SAMPLE_DATA.previousApplicationDate;
+		const prevEndDate = addMonths(prevStart, SAMPLE_DATA.periodDuration);
+		writeText(eff(layout.right.current_pass_validity_from), formatDate(prevStart));
+		writeText(eff(layout.right.current_pass_validity_to), formatDate(prevEndDate));
+
+		writeText(eff(layout.right.date_of_issue_right), formatDate(now));
+
+		const pdfBytes = doc.output("arraybuffer");
+
+		const pdfDoc = await PDFDocument.load(pdfBytes);
+		const pages = pdfDoc.getPages();
+		const page = pages[0];
+		page.setRotation(degrees(90));
+
+		const rotatedPdfBytes = await pdfDoc.save();
+		const pdfBase64 = `data:application/pdf;base64,${Buffer.from(rotatedPdfBytes).toString("base64")}`;
+
+		return success(pdfBase64);
+	} catch (error) {
+		console.error("Error generating sample overlay PDF:", error);
+		const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
+		return failure(databaseError(`Failed to generate sample overlay PDF: ${errorMessage}`));
+	}
+};

--- a/src/components/admin/address-change-requests-table.tsx
+++ b/src/components/admin/address-change-requests-table.tsx
@@ -1,4 +1,5 @@
 import {
+	X,
 	Eye,
 	User,
 	Home,
@@ -98,6 +99,7 @@ const AddressChangeRequestDetailsDialog = ({
 	const [isApproving, setIsApproving] = useState<boolean>(false);
 	const [isRejecting, setIsRejecting] = useState<boolean>(false);
 	const [rejectionReason, setRejectionReason] = useState<string>("");
+	const [showDocViewer, setShowDocViewer] = useState<boolean>(false);
 	const [showRejectDialog, setShowRejectDialog] = useState<boolean>(false);
 	const [selectedPredefinedReason, setSelectedPredefinedReason] = useState<string>("");
 	const [requestDetails, setRequestDetails] = useState<AddressChangeRequestItem | null>(null);
@@ -153,6 +155,7 @@ const AddressChangeRequestDetailsDialog = ({
 
 				setRequestDetails(updatedRequest);
 				onRequestUpdate?.(updatedRequest);
+				setShowDocViewer(false);
 				setIsOpen(false);
 				return updatedRequest;
 			} else {
@@ -211,6 +214,7 @@ const AddressChangeRequestDetailsDialog = ({
 				setShowRejectDialog(false);
 				setRejectionReason("");
 				setSelectedPredefinedReason("");
+				setShowDocViewer(false);
 				setIsOpen(false);
 				return updatedRequest;
 			} else {
@@ -239,6 +243,12 @@ const AddressChangeRequestDetailsDialog = ({
 		} else {
 			setRequestDetails(null);
 			setHasError(false);
+
+			const timeout = setTimeout(() => {
+				setShowDocViewer(false);
+			}, 200);
+
+			return () => clearTimeout(timeout);
 		}
 	}, [isOpen, loadRequestDetails]);
 
@@ -251,7 +261,15 @@ const AddressChangeRequestDetailsDialog = ({
 					</Button>
 				</DialogTrigger>
 
-				<DialogContent className="sm:max-w-4xl max-h-[90vh] overflow-y-auto">
+				<DialogContent
+					closeClassName="top-4 right-4 z-50"
+					onFocusOutside={(e) => e.preventDefault()}
+					onInteractOutside={(e) => e.preventDefault()}
+					onPointerDownOutside={(e) => e.preventDefault()}
+					className={`max-h-[90vh] transition-[max-width,width,height] duration-500 ease-in-out ${
+						showDocViewer ? "sm:max-w-[95vw] w-[95vw] h-[90vh] overflow-hidden pt-12" : "sm:max-w-3xl overflow-y-auto"
+					}`}
+				>
 					{isLoading ? (
 						<div className="space-y-0">
 							<div className="flex mt-4 items-center justify-between pb-6">
@@ -417,218 +435,258 @@ const AddressChangeRequestDetailsDialog = ({
 							</div>
 						</div>
 					) : requestDetails ? (
-						<div className="space-y-0">
-							<div className="flex mt-4 items-center justify-between pb-6">
-								<div className="flex items-center gap-3">
-									<div className="size-10 bg-primary/20 rounded-lg flex items-center justify-center">
-										<MapPin className="size-5" />
-									</div>
-									<div>
-										<h3 className="font-semibold text-lg">Address Change Request</h3>
-										<p className="text-sm text-muted-foreground">
-											{toTitleCase(
-												`${requestDetails.student.firstName} ${requestDetails.student.middleName} ${requestDetails.student.lastName}`
-											)}
-										</p>
-									</div>
-								</div>
-
-								<StatusBadge status={requestDetails.status} />
-							</div>
-
-							<Separator />
-
-							<div className="py-6">
-								<h4 className="font-medium text-sm text-muted-foreground uppercase tracking-wide mb-4">
-									Student Information
-								</h4>
-								<div className="space-y-3">
+						<div
+							className={`flex h-full transition-[gap] duration-500 ease-in-out ${showDocViewer ? "gap-6" : "gap-0"}`}
+						>
+							<div
+								className={`space-y-0 overflow-y-auto transition-[width] duration-500 ease-in-out pr-4 ${
+									showDocViewer ? "w-[45%] shrink-0" : "w-full"
+								}`}
+								style={{ maxHeight: showDocViewer ? "calc(90vh - 4.5rem)" : undefined }}
+							>
+								<div className="flex mt-4 items-center justify-between pb-6">
 									<div className="flex items-center gap-3">
-										<User className="size-4 text-muted-foreground" />
+										<div className="size-10 bg-primary/20 rounded-lg flex items-center justify-center">
+											<MapPin className="size-5" />
+										</div>
 										<div>
-											<p className="text-sm font-medium">
+											<h3 className="font-semibold text-lg">Address Change Request</h3>
+											<p className="text-sm text-muted-foreground">
 												{toTitleCase(
 													`${requestDetails.student.firstName} ${requestDetails.student.middleName} ${requestDetails.student.lastName}`
 												)}
 											</p>
-											<p className="text-xs text-muted-foreground">{requestDetails.student.user.email}</p>
 										</div>
 									</div>
-									<div className="flex items-center gap-3">
-										<FileText className="size-4 text-muted-foreground" />
-										<div>
-											<p className="text-sm font-medium">{requestDetails.student.class.code}</p>
-											<p className="text-xs text-muted-foreground">
-												{requestDetails.student.class.year.name} - {requestDetails.student.class.branch.name}
-											</p>
-										</div>
-									</div>
-								</div>
-							</div>
 
-							<Separator />
-
-							<div className="grid grid-cols-1 lg:grid-cols-2 gap-8 py-6">
-								<div className="space-y-6">
-									<div>
-										<h4 className="font-medium text-sm text-muted-foreground uppercase tracking-wide mb-4">
-											Current Details
-										</h4>
-										<div className="space-y-3">
-											<div className="flex items-center gap-3">
-												<Train className="size-4 text-muted-foreground" />
-												<div>
-													<p className="text-sm font-medium">{requestDetails.currentStation.name}</p>
-													<p className="text-xs text-muted-foreground">{requestDetails.currentStation.code}</p>
-												</div>
-											</div>
-											<div className="flex items-start gap-3">
-												<Home className="size-4 text-muted-foreground mt-0.5" />
-												<div className="flex-1">
-													<p className="text-xs font-medium text-muted-foreground mb-1">Current Address</p>
-													<div className="p-3 bg-muted/50 rounded-md">
-														<p className="text-sm">{requestDetails.currentAddress}</p>
-													</div>
-												</div>
-											</div>
-										</div>
-									</div>
+									<StatusBadge status={requestDetails.status} />
 								</div>
 
-								<div className="space-y-6">
-									<div>
-										<h4 className="font-medium text-sm text-muted-foreground uppercase tracking-wide mb-4">
-											Requested Changes
-										</h4>
-										<div className="space-y-3">
-											<div className="flex items-center gap-3">
-												<Train className="size-4 text-muted-foreground" />
-												<div>
-													<p className="text-sm font-medium">{requestDetails.newStation.name}</p>
-													<p className="text-xs text-muted-foreground">{requestDetails.newStation.code}</p>
-												</div>
-											</div>
-											<div className="flex items-start gap-3">
-												<Home className="size-4 text-muted-foreground mt-0.5" />
-												<div className="flex-1">
-													<p className="text-xs font-medium text-muted-foreground mb-1">New Address</p>
-													<div className="p-3 bg-muted/50 rounded-md">
-														<p className="text-sm">{requestDetails.newAddress}</p>
-													</div>
-												</div>
-											</div>
-										</div>
-									</div>
-								</div>
-							</div>
+								<Separator />
 
-							<Separator />
-
-							{requestDetails.verificationDocUrl && (
 								<div className="py-6">
 									<h4 className="font-medium text-sm text-muted-foreground uppercase tracking-wide mb-4">
-										Verification Document
+										Student Information
 									</h4>
-									<div className="flex items-center gap-2 p-3 bg-muted/50 rounded-lg border">
-										<FileText className="size-4 text-muted-foreground" />
-										<span className="text-sm font-medium flex-1">Student Verification Document</span>
-										<Button
-											size="sm"
-											variant="default"
-											onClick={() => {
-												if (requestDetails.verificationDocUrl) {
-													window.open(requestDetails.verificationDocUrl, "_blank");
-												}
-											}}
-										>
-											<ExternalLink className="size-4 mr-1" />
-											View
-										</Button>
-									</div>
-								</div>
-							)}
-
-							<Separator />
-
-							<div className="space-y-6 py-6">
-								<h4 className="font-medium text-sm text-muted-foreground uppercase tracking-wide">
-									Application Status
-								</h4>
-
-								<div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
 									<div className="space-y-3">
-										<div className="flex items-center justify-between">
-											<span className="text-sm font-medium text-muted-foreground">Submissions</span>
-											<span className="text-sm text-foreground">{requestDetails.submissionCount}</span>
-										</div>
-
-										<div className="flex items-center justify-between">
-											<span className="text-sm font-medium text-muted-foreground">Applied Date</span>
-											<span className="text-sm text-foreground">
-												{format(new Date(requestDetails.createdAt), "MMM dd, yyyy")}
-											</span>
-										</div>
-									</div>
-
-									<div className="space-y-3">
-										{requestDetails.reviewedAt && (
-											<div className="flex items-center justify-between">
-												<span className="text-sm font-medium text-muted-foreground">Reviewed Date</span>
-												<span className="text-sm text-foreground">
-													{format(new Date(requestDetails.reviewedAt), "MMM dd, yyyy")}
-												</span>
+										<div className="flex items-center gap-3">
+											<User className="size-4 text-muted-foreground" />
+											<div>
+												<p className="text-sm font-medium">
+													{toTitleCase(
+														`${requestDetails.student.firstName} ${requestDetails.student.middleName} ${requestDetails.student.lastName}`
+													)}
+												</p>
+												<p className="text-xs text-muted-foreground">{requestDetails.student.user.email}</p>
 											</div>
-										)}
-
-										{requestDetails.reviewedBy && (
-											<div className="flex items-center justify-between">
-												<span className="text-sm font-medium text-muted-foreground">Reviewed By</span>
-												<span className="text-sm text-foreground">
-													{toTitleCase(requestDetails.reviewedBy.user.name)}
-												</span>
+										</div>
+										<div className="flex items-center gap-3">
+											<FileText className="size-4 text-muted-foreground" />
+											<div>
+												<p className="text-sm font-medium">{requestDetails.student.class.code}</p>
+												<p className="text-xs text-muted-foreground">
+													{requestDetails.student.class.year.name} - {requestDetails.student.class.branch.name}
+												</p>
 											</div>
-										)}
+										</div>
 									</div>
 								</div>
 
-								{requestDetails.rejectionReason && (
-									<div className="mt-6">
-										<p className="text-sm font-medium text-muted-foreground mb-4">Rejection Reason</p>
-										<div className="p-3 bg-destructive/10 border border-destructive/20 rounded-lg">
-											<p className="text-sm text-destructive">{requestDetails.rejectionReason}</p>
+								<Separator />
+
+								<div className="grid grid-cols-1 lg:grid-cols-2 gap-8 py-6">
+									<div className="space-y-6">
+										<div>
+											<h4 className="font-medium text-sm text-muted-foreground uppercase tracking-wide mb-4">
+												Current Details
+											</h4>
+											<div className="space-y-3">
+												<div className="flex items-center gap-3">
+													<Train className="size-4 text-muted-foreground" />
+													<div>
+														<p className="text-sm font-medium">{requestDetails.currentStation.name}</p>
+														<p className="text-xs text-muted-foreground">{requestDetails.currentStation.code}</p>
+													</div>
+												</div>
+												<div className="flex items-start gap-3">
+													<Home className="size-4 text-muted-foreground mt-0.5" />
+													<div className="flex-1">
+														<p className="text-xs font-medium text-muted-foreground mb-1">Current Address</p>
+														<div className="p-3 bg-muted/50 rounded-md">
+															<p className="text-sm">{requestDetails.currentAddress}</p>
+														</div>
+													</div>
+												</div>
+											</div>
+										</div>
+									</div>
+
+									<div className="space-y-6">
+										<div>
+											<h4 className="font-medium text-sm text-muted-foreground uppercase tracking-wide mb-4">
+												Requested Changes
+											</h4>
+											<div className="space-y-3">
+												<div className="flex items-center gap-3">
+													<Train className="size-4 text-muted-foreground" />
+													<div>
+														<p className="text-sm font-medium">{requestDetails.newStation.name}</p>
+														<p className="text-xs text-muted-foreground">{requestDetails.newStation.code}</p>
+													</div>
+												</div>
+												<div className="flex items-start gap-3">
+													<Home className="size-4 text-muted-foreground mt-0.5" />
+													<div className="flex-1">
+														<p className="text-xs font-medium text-muted-foreground mb-1">New Address</p>
+														<div className="p-3 bg-muted/50 rounded-md">
+															<p className="text-sm">{requestDetails.newAddress}</p>
+														</div>
+													</div>
+												</div>
+											</div>
+										</div>
+									</div>
+								</div>
+
+								<Separator />
+
+								{requestDetails.verificationDocUrl && (
+									<div className="space-y-4">
+										<h4 className="font-medium text-sm text-muted-foreground uppercase tracking-wide">
+											Verification Document
+										</h4>
+										<div className="flex items-center gap-2 p-3 bg-muted/50 rounded-lg border">
+											<FileText className="size-4 text-muted-foreground" />
+											<span className="text-sm font-medium flex-1">Student Verification Document</span>
+											<Button
+												size="sm"
+												variant={showDocViewer ? "destructive" : "default"}
+												onClick={() => setShowDocViewer(!showDocViewer)}
+											>
+												{showDocViewer ? (
+													<>
+														<X className="size-4 mr-1" />
+														Close
+													</>
+												) : (
+													<>
+														<Eye className="size-4 mr-1" />
+														View
+													</>
+												)}
+											</Button>
+										</div>
+									</div>
+								)}
+
+								<Separator />
+
+								<div className="space-y-6 py-6">
+									<h4 className="font-medium text-sm text-muted-foreground uppercase tracking-wide">
+										Application Status
+									</h4>
+
+									<div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+										<div className="space-y-3">
+											<div className="flex items-center justify-between">
+												<span className="text-sm font-medium text-muted-foreground">Submissions</span>
+												<span className="text-sm text-foreground">{requestDetails.submissionCount}</span>
+											</div>
+
+											<div className="flex items-center justify-between">
+												<span className="text-sm font-medium text-muted-foreground">Applied Date</span>
+												<span className="text-sm text-foreground">
+													{format(new Date(requestDetails.createdAt), "MMM dd, yyyy")}
+												</span>
+											</div>
+										</div>
+
+										<div className="space-y-3">
+											{requestDetails.reviewedAt && (
+												<div className="flex items-center justify-between">
+													<span className="text-sm font-medium text-muted-foreground">Reviewed Date</span>
+													<span className="text-sm text-foreground">
+														{format(new Date(requestDetails.reviewedAt), "MMM dd, yyyy")}
+													</span>
+												</div>
+											)}
+
+											{requestDetails.reviewedBy && (
+												<div className="flex items-center justify-between">
+													<span className="text-sm font-medium text-muted-foreground">Reviewed By</span>
+													<span className="text-sm text-foreground">
+														{toTitleCase(requestDetails.reviewedBy.user.name)}
+													</span>
+												</div>
+											)}
+										</div>
+									</div>
+
+									{requestDetails.rejectionReason && (
+										<div className="mt-6">
+											<p className="text-sm font-medium text-muted-foreground mb-4">Rejection Reason</p>
+											<div className="p-3 bg-destructive/10 border border-destructive/20 rounded-lg">
+												<p className="text-sm text-destructive">{requestDetails.rejectionReason}</p>
+											</div>
+										</div>
+									)}
+								</div>
+
+								{requestDetails.status === "Pending" && (
+									<>
+										<Separator />
+										<div className="flex justify-end gap-4 pt-6">
+											<Button
+												variant="destructive"
+												className="w-38 h-10"
+												title="Reject Request"
+												aria-label="Reject Request"
+												disabled={isApproving || isRejecting}
+												onClick={() => setShowRejectDialog(true)}
+											>
+												<XCircle className="size-4 mr-1" />
+												Reject Request
+											</Button>
+											<Button
+												title="Approve Request"
+												onClick={handleApprove}
+												aria-label="Approve Request"
+												disabled={isApproving || isRejecting}
+												className="w-42 h-10 p-0 bg-emerald-600 hover:bg-emerald-700 text-white"
+											>
+												<Check className="size-4 mr-1" />
+												Approve Request
+											</Button>
+										</div>
+									</>
+								)}
+							</div>
+
+							<div
+								style={{ maxHeight: "calc(90vh - 4.5rem)" }}
+								className={`relative rounded-xl border bg-muted/30 overflow-hidden transition-[width,opacity] duration-500 ease-in-out ${
+									showDocViewer ? "w-[55%] opacity-100" : "w-0 opacity-0 border-0"
+								}`}
+							>
+								{showDocViewer && requestDetails.verificationDocUrl && (
+									<div className="flex flex-col h-full animate-in fade-in duration-300">
+										<div className="flex items-center justify-between px-4 py-3 border-b bg-background/80 backdrop-blur-sm">
+											<div className="flex items-center gap-2">
+												<FileText className="size-4 text-muted-foreground" />
+												<span className="text-sm font-semibold">Verification Document</span>
+											</div>
+										</div>
+
+										<div className="flex-1 min-w-0">
+											<iframe
+												title="Verification Document"
+												className="w-full h-full border-0"
+												src={requestDetails.verificationDocUrl}
+											/>
 										</div>
 									</div>
 								)}
 							</div>
-
-							{requestDetails.status === "Pending" && (
-								<>
-									<Separator />
-									<div className="flex justify-end gap-4 pt-6">
-										<Button
-											variant="destructive"
-											className="w-38 h-10"
-											title="Reject Request"
-											aria-label="Reject Request"
-											disabled={isApproving || isRejecting}
-											onClick={() => setShowRejectDialog(true)}
-										>
-											<XCircle className="size-4 mr-1" />
-											Reject Request
-										</Button>
-										<Button
-											title="Approve Request"
-											onClick={handleApprove}
-											aria-label="Approve Request"
-											disabled={isApproving || isRejecting}
-											className="w-42 h-10 p-0 bg-emerald-600 hover:bg-emerald-700 text-white"
-										>
-											<Check className="size-4 mr-1" />
-											Approve Request
-										</Button>
-									</div>
-								</>
-							)}
 						</div>
 					) : null}
 				</DialogContent>

--- a/src/components/admin/anchor-calibration-dialog.tsx
+++ b/src/components/admin/anchor-calibration-dialog.tsx
@@ -1,0 +1,309 @@
+"use client";
+
+import {
+	Dialog,
+	DialogTitle,
+	DialogFooter,
+	DialogHeader,
+	DialogContent,
+	DialogDescription
+} from "@/components/ui/dialog";
+import { toast } from "sonner";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { useState, useCallback, useEffect } from "react";
+import { BookletItem, updateBookletAnchorCoordinates } from "@/actions/booklets";
+import { generateSampleOverlayPDF } from "@/actions/generate-sample-overlay-pdf";
+import { Minus, Plus, RotateCcw, Loader2, FileDown, Save, Crosshair } from "lucide-react";
+
+type AnchorCalibrationDialogProps = {
+	isOpen: boolean;
+	onClose: () => void;
+	booklet: BookletItem | null;
+	onAnchorUpdate?: (bookletId: string, anchorX: number, anchorY: number) => void;
+};
+
+const AnchorCalibrationDialog: React.FC<AnchorCalibrationDialogProps> = ({
+	isOpen,
+	onClose,
+	booklet,
+	onAnchorUpdate
+}) => {
+	const [originalX, setOriginalX] = useState<number>(0);
+	const [originalY, setOriginalY] = useState<number>(0);
+	const [adjustedX, setAdjustedX] = useState<number>(0);
+	const [adjustedY, setAdjustedY] = useState<number>(0);
+	const [isGenerating, setIsGenerating] = useState<boolean>(false);
+	const [isUpdating, setIsUpdating] = useState<boolean>(false);
+
+	useEffect(() => {
+		if (isOpen && booklet) {
+			// eslint-disable-next-line react-hooks/set-state-in-effect -- This effect is triggered when the dialog opens and the booklet is available. It sets the original and adjusted coordinates based on the booklet's anchor values.
+			setOriginalX(booklet.anchorX);
+			setOriginalY(booklet.anchorY);
+			setAdjustedX(booklet.anchorX);
+			setAdjustedY(booklet.anchorY);
+		}
+	}, [isOpen, booklet]);
+
+	const handleClose = useCallback(() => {
+		setAdjustedX(originalX);
+		setAdjustedY(originalY);
+		setIsGenerating(false);
+		setIsUpdating(false);
+		onClose();
+	}, [originalX, originalY, onClose]);
+
+	const handleReset = useCallback(() => {
+		setAdjustedX(originalX);
+		setAdjustedY(originalY);
+	}, [originalX, originalY]);
+
+	const handleAdjustX = useCallback((delta: number) => {
+		setAdjustedX((prev) => {
+			const next = Math.round((prev + delta) * 100) / 100;
+			return Math.max(0, Math.min(100, next));
+		});
+	}, []);
+
+	const handleAdjustY = useCallback((delta: number) => {
+		setAdjustedY((prev) => {
+			const next = Math.round((prev + delta) * 100) / 100;
+			return Math.max(0, Math.min(100, next));
+		});
+	}, []);
+
+	const handleInputChangeX = useCallback((value: string) => {
+		const num = parseFloat(value);
+		if (!isNaN(num) && num >= 0 && num <= 100) {
+			setAdjustedX(num);
+		} else if (value === "" || value === "-") {
+			setAdjustedX(0);
+		}
+	}, []);
+
+	const handleInputChangeY = useCallback((value: string) => {
+		const num = parseFloat(value);
+		if (!isNaN(num) && num >= 0 && num <= 100) {
+			setAdjustedY(num);
+		} else if (value === "" || value === "-") {
+			setAdjustedY(0);
+		}
+	}, []);
+
+	const handleGeneratePDF = useCallback(async () => {
+		setIsGenerating(true);
+
+		try {
+			const result = await generateSampleOverlayPDF(adjustedX, adjustedY);
+
+			if (result.isSuccess) {
+				window.open(result.data, "_blank");
+				toast.success("Sample PDF Generated", {
+					description: `Preview opened in a new tab with anchor (${adjustedX}, ${adjustedY}).`
+				});
+			} else {
+				toast.error("Generation Failed", {
+					description: result.error.message || "Failed to generate sample overlay PDF."
+				});
+			}
+		} catch (error) {
+			console.error("Error generating sample PDF:", error);
+			toast.error("Generation Failed", {
+				description: "An unexpected error occurred while generating the PDF."
+			});
+		} finally {
+			setIsGenerating(false);
+		}
+	}, [adjustedX, adjustedY]);
+
+	const handleUpdateCoordinates = useCallback(async () => {
+		if (!booklet) return;
+
+		setIsUpdating(true);
+
+		const updatePromise = async () => {
+			const result = await updateBookletAnchorCoordinates(booklet.id, adjustedX, adjustedY);
+
+			if (result.isSuccess) {
+				onAnchorUpdate?.(booklet.id, adjustedX, adjustedY);
+				onClose();
+				return result.data;
+			} else {
+				throw new Error(result.error.message || "Failed to update anchor coordinates.");
+			}
+		};
+
+		toast.promise(updatePromise, {
+			loading: "Updating anchor coordinates...",
+			success: `Anchor coordinates updated to (${adjustedX}, ${adjustedY})`,
+			error: (error) => error.message || "Failed to update anchor coordinates",
+			finally: () => {
+				setIsUpdating(false);
+			}
+		});
+	}, [booklet, adjustedX, adjustedY, onAnchorUpdate, onClose]);
+
+	const hasChanges = adjustedX !== originalX || adjustedY !== originalY;
+
+	if (!booklet) return null;
+
+	return (
+		<Dialog open={isOpen} onOpenChange={handleClose}>
+			<DialogContent className="sm:max-w-lg">
+				<DialogHeader>
+					<DialogTitle className="flex items-center gap-2">
+						<Crosshair className="size-5" />
+						Anchor Calibration — Booklet #{booklet.bookletNumber}
+					</DialogTitle>
+					<DialogDescription>
+						Adjust anchor coordinates and generate sample PDFs to verify alignment before saving.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="space-y-5">
+					<div className="space-y-2">
+						<Label className="text-sm font-medium text-muted-foreground">Saved Coordinates</Label>
+						<div className="flex items-center gap-3 p-3 bg-muted/30 rounded-lg border">
+							<div className="flex-1 text-center">
+								<div className="text-xs text-muted-foreground mb-1">Anchor X</div>
+								<div className="font-mono text-sm font-semibold">{originalX}</div>
+							</div>
+							<div className="w-px h-8 bg-border" />
+							<div className="flex-1 text-center">
+								<div className="text-xs text-muted-foreground mb-1">Anchor Y</div>
+								<div className="font-mono text-sm font-semibold">{originalY}</div>
+							</div>
+						</div>
+					</div>
+
+					<div className="space-y-3">
+						<div className="flex items-center justify-between">
+							<Label className="text-sm font-medium">Adjust Coordinates</Label>
+							<Button
+								size="sm"
+								variant="ghost"
+								disabled={!hasChanges}
+								onClick={handleReset}
+								className="h-7 px-2 text-xs text-muted-foreground hover:text-foreground"
+							>
+								<RotateCcw className="size-3 mr-1" />
+								Reset
+							</Button>
+						</div>
+
+						<div className="grid grid-cols-2 gap-4">
+							<div className="space-y-2">
+								<Label htmlFor="calibrate-anchor-x" className="text-xs text-muted-foreground">
+									Anchor X
+								</Label>
+								<div className="flex items-center gap-1.5">
+									<Button
+										size="icon"
+										variant="outline"
+										disabled={adjustedX <= 0}
+										className="size-8 shrink-0"
+										onClick={() => handleAdjustX(-1)}
+									>
+										<Minus className="size-3" />
+									</Button>
+									<Input
+										min="0"
+										step="1"
+										max="100"
+										type="number"
+										value={adjustedX}
+										id="calibrate-anchor-x"
+										className="text-center font-mono h-8 text-sm"
+										onChange={(e) => handleInputChangeX(e.target.value)}
+									/>
+									<Button
+										size="icon"
+										variant="outline"
+										disabled={adjustedX >= 100}
+										className="size-8 shrink-0"
+										onClick={() => handleAdjustX(1)}
+									>
+										<Plus className="size-3" />
+									</Button>
+								</div>
+							</div>
+
+							<div className="space-y-2">
+								<Label htmlFor="calibrate-anchor-y" className="text-xs text-muted-foreground">
+									Anchor Y
+								</Label>
+								<div className="flex items-center gap-1.5">
+									<Button
+										size="icon"
+										variant="outline"
+										disabled={adjustedY <= 0}
+										className="size-8 shrink-0"
+										onClick={() => handleAdjustY(-1)}
+									>
+										<Minus className="size-3" />
+									</Button>
+									<Input
+										min="0"
+										step="1"
+										max="100"
+										type="number"
+										value={adjustedY}
+										id="calibrate-anchor-y"
+										className="text-center font-mono h-8 text-sm"
+										onChange={(e) => handleInputChangeY(e.target.value)}
+									/>
+									<Button
+										size="icon"
+										variant="outline"
+										disabled={adjustedY >= 100}
+										className="size-8 shrink-0"
+										onClick={() => handleAdjustY(1)}
+									>
+										<Plus className="size-3" />
+									</Button>
+								</div>
+							</div>
+						</div>
+					</div>
+
+					<Button variant="outline" className="w-full" disabled={isGenerating} onClick={handleGeneratePDF}>
+						{isGenerating ? (
+							<>
+								<Loader2 className="size-4 mr-2 animate-spin" />
+								Generating Sample PDF...
+							</>
+						) : (
+							<>
+								<FileDown className="size-4 mr-2" />
+								Generate Sample PDF
+							</>
+						)}
+					</Button>
+				</div>
+
+				<DialogFooter className="gap-4 pt-2">
+					<Button variant="outline" onClick={handleClose} disabled={isUpdating}>
+						Cancel
+					</Button>
+					<Button onClick={handleUpdateCoordinates} disabled={isUpdating || !hasChanges}>
+						{isUpdating ? (
+							<>
+								<Loader2 className="size-4 mr-1 animate-spin" />
+								Updating...
+							</>
+						) : (
+							<>
+								<Save className="size-4 mr-1" />
+								Update Coordinates
+							</>
+						)}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};
+
+export default AnchorCalibrationDialog;

--- a/src/components/admin/booklets-table.tsx
+++ b/src/components/admin/booklets-table.tsx
@@ -7,6 +7,7 @@ import {
 	Filter,
 	Trash2,
 	BookOpen,
+	Crosshair,
 	ChevronLeft,
 	AlertCircle,
 	ArrowUpDown,
@@ -43,6 +44,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { ConcessionBookletStatusType } from "@/generated/zod";
 import { BookletItem, deleteBooklet } from "@/actions/booklets";
 import { useState, useMemo, useCallback, useEffect } from "react";
+import AnchorCalibrationDialog from "@/components/admin/anchor-calibration-dialog";
 import { Table, TableRow, TableBody, TableCell, TableHead, TableHeader } from "@/components/ui/table";
 import { Select, SelectItem, SelectValue, SelectContent, SelectTrigger } from "@/components/ui/select";
 import { ColumnDef, flexRender, useReactTable, VisibilityState, getCoreRowModel } from "@tanstack/react-table";
@@ -106,12 +108,14 @@ const BookletsTable = ({
 		direction: SortOrder;
 	} | null>(null);
 
+	const [isDeleting, setIsDeleting] = useState<boolean>(false);
 	const [selectedStatus, setSelectedStatus] = useState<string>("all");
 	const [showDeleteDialog, setShowDeleteDialog] = useState<boolean>(false);
 	const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
 	const [localSearchQuery, setLocalSearchQuery] = useState<string>(searchQuery);
 	const [bookletToDelete, setBookletToDelete] = useState<BookletItem | null>(null);
-	const [isDeleting, setIsDeleting] = useState<boolean>(false);
+	const [showCalibrationDialog, setShowCalibrationDialog] = useState<boolean>(false);
+	const [calibrationBooklet, setCalibrationBooklet] = useState<BookletItem | null>(null);
 
 	const handleSort = useCallback((key: keyof BookletItem | "bookletNumber") => {
 		setSortConfig((current) => {
@@ -165,6 +169,27 @@ const BookletsTable = ({
 			router.push(`/dashboard/admin/booklets/${booklet.id}/update`);
 		},
 		[router]
+	);
+
+	const handleCalibrateClick = useCallback((booklet: BookletItem) => {
+		setCalibrationBooklet(booklet);
+		setShowCalibrationDialog(true);
+	}, []);
+
+	const handleCalibrationClose = useCallback(() => {
+		setShowCalibrationDialog(false);
+		setCalibrationBooklet(null);
+	}, []);
+
+	const handleAnchorUpdate = useCallback(
+		(bookletId: string, anchorX: number, anchorY: number) => {
+			const updatedBooklet = booklets.find((b) => b.id === bookletId);
+			if (updatedBooklet) {
+				updatedBooklet.anchorX = anchorX;
+				updatedBooklet.anchorY = anchorY;
+			}
+		},
+		[booklets]
 	);
 
 	const handleDeleteConfirm = useCallback(async () => {
@@ -393,6 +418,10 @@ const BookletsTable = ({
 									<Edit className="mr-2 size-4" />
 									Edit Booklet
 								</DropdownMenuItem>
+								<DropdownMenuItem onClick={() => handleCalibrateClick(row.original)}>
+									<Crosshair className="mr-2 size-4" />
+									Calibrate Anchors
+								</DropdownMenuItem>
 								<DropdownMenuSeparator />
 								<DropdownMenuItem
 									onClick={() => handleDeleteClick(row.original)}
@@ -407,7 +436,7 @@ const BookletsTable = ({
 				)
 			}
 		],
-		[handleSort, currentPage, handleDeleteClick, handleUpdateClick]
+		[handleSort, currentPage, handleDeleteClick, handleUpdateClick, handleCalibrateClick]
 	);
 
 	const table = useReactTable({
@@ -686,6 +715,13 @@ const BookletsTable = ({
 					</AlertDialogFooter>
 				</AlertDialogContent>
 			</AlertDialog>
+
+			<AnchorCalibrationDialog
+				booklet={calibrationBooklet}
+				isOpen={showCalibrationDialog}
+				onClose={handleCalibrationClose}
+				onAnchorUpdate={handleAnchorUpdate}
+			/>
 		</div>
 	);
 };

--- a/src/components/onboarding/multi-step-form.tsx
+++ b/src/components/onboarding/multi-step-form.tsx
@@ -47,7 +47,7 @@ const OnboardingFormSkeleton = () => (
 			</div>
 		</CardHeader>
 
-		<CardContent className="mt-8">
+		<CardContent>
 			<div className="space-y-6">
 				<div className="grid grid-cols-1 gap-6 md:grid-cols-3">
 					{[1, 2, 3].map((item) => (
@@ -427,7 +427,7 @@ const MultiStepForm = () => {
 			</CardHeader>
 
 			{rejectionInfo && (
-				<div className="px-6 py-4">
+				<div className="px-6">
 					<div className="bg-card border border-border rounded-lg py-6 pl-2 pr-6 md:p-6 shadow-sm">
 						<div className="flex items-start gap-4">
 							<div className="shrink-0">
@@ -477,7 +477,7 @@ const MultiStepForm = () => {
 				</div>
 			)}
 
-			<CardContent className="mt-8">
+			<CardContent>
 				{renderStep()}
 
 				{currentStep != totalSteps && (

--- a/src/components/onboarding/steps/review.tsx
+++ b/src/components/onboarding/steps/review.tsx
@@ -29,7 +29,6 @@ import posthog from "posthog-js";
 import { format } from "date-fns";
 import Status from "@/components/ui/status";
 import { useRouter } from "next/navigation";
-import { Badge } from "@/components/ui/badge";
 import { authClient } from "@/lib/auth-client";
 import { Button } from "@/components/ui/button";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -51,35 +50,114 @@ const ReviewSkeleton = () => {
 
 	return (
 		<div className="max-w-5xl mx-auto space-y-6">
-			{[1, 2, 3, 4].map((index) => (
-				<Card key={index} className="shadow-sm">
-					<CardHeader className="pb-4">
-						<div className="flex items-center gap-3">
-							<Skeleton className="size-10 rounded-lg" />
-							<div className="flex-1 space-y-2">
-								<Skeleton className="h-5 w-40" />
-								<Skeleton className="h-4 w-32" />
-							</div>
-							<Skeleton className="w-10 h-8 rounded-md" />
+			<Card className="shadow-sm">
+				<CardHeader className="pb-4">
+					<div className="flex items-center gap-3">
+						<Skeleton className="size-10 rounded-lg" />
+						<div className="flex-1 space-y-2">
+							<Skeleton className="h-5 w-40" />
+							<Skeleton className="h-4 w-32" />
 						</div>
-					</CardHeader>
-					<CardContent className="space-y-4">
-						<div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-							{[1, 2].map((item) => (
-								<div key={item} className="space-y-2">
-									<Skeleton className="h-4 w-24" />
-									<Skeleton className="h-5 w-full" />
-								</div>
-							))}
-						</div>
-						<Separator />
+						<Skeleton className="w-16 h-8 rounded-md" />
+					</div>
+				</CardHeader>
+				<CardContent className="space-y-4">
+					<div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
 						<div className="space-y-2">
 							<Skeleton className="h-4 w-20" />
-							<Skeleton className="h-5 w-full" />
+							<Skeleton className="h-5 w-36" />
 						</div>
-					</CardContent>
-				</Card>
-			))}
+						<div className="space-y-2">
+							<Skeleton className="h-4 w-24" />
+							<Skeleton className="h-5 w-28" />
+						</div>
+						<div className="space-y-2">
+							<Skeleton className="h-4 w-16" />
+							<Skeleton className="h-5 w-16" />
+						</div>
+					</div>
+					<Separator />
+					<div className="space-y-2">
+						<Skeleton className="h-4 w-16" />
+						<Skeleton className="h-5 w-3/4" />
+					</div>
+				</CardContent>
+			</Card>
+
+			<Card className="shadow-sm">
+				<CardHeader className="pb-4">
+					<div className="flex items-center gap-3">
+						<Skeleton className="size-10 rounded-lg" />
+						<div className="flex-1 space-y-2">
+							<Skeleton className="h-5 w-44" />
+							<Skeleton className="h-4 w-36" />
+						</div>
+						<Skeleton className="w-16 h-8 rounded-md" />
+					</div>
+				</CardHeader>
+				<CardContent className="space-y-4">
+					<div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+						<div className="space-y-2">
+							<Skeleton className="h-4 w-12" />
+							<Skeleton className="h-5 w-24" />
+						</div>
+						<div className="space-y-2">
+							<Skeleton className="h-4 w-16" />
+							<Skeleton className="h-5 w-32" />
+						</div>
+						<div className="space-y-2">
+							<Skeleton className="h-4 w-14" />
+							<Skeleton className="h-5 w-20" />
+						</div>
+					</div>
+				</CardContent>
+			</Card>
+
+			<Card className="shadow-sm">
+				<CardHeader className="pb-4">
+					<div className="flex items-center gap-3">
+						<Skeleton className="size-10 rounded-lg" />
+						<div className="flex-1 space-y-2">
+							<Skeleton className="h-5 w-36" />
+							<Skeleton className="h-4 w-40" />
+						</div>
+						<Skeleton className="w-16 h-8 rounded-md" />
+					</div>
+				</CardHeader>
+				<CardContent className="space-y-4">
+					<div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+						<div className="space-y-2">
+							<Skeleton className="h-4 w-24" />
+							<Skeleton className="h-5 w-32" />
+						</div>
+						<div className="space-y-2">
+							<Skeleton className="h-4 w-44" />
+							<Skeleton className="h-5 w-28" />
+						</div>
+					</div>
+					<div className="space-y-2">
+						<Skeleton className="h-4 w-44" />
+						<Skeleton className="h-5 w-36" />
+					</div>
+				</CardContent>
+			</Card>
+
+			<Card className="shadow-sm">
+				<CardHeader className="pb-4">
+					<div className="flex items-center gap-3">
+						<Skeleton className="size-10 rounded-lg" />
+						<div className="flex-1 space-y-2">
+							<Skeleton className="h-5 w-44" />
+							<Skeleton className="h-4 w-36" />
+						</div>
+						<Skeleton className="w-16 h-8 rounded-md" />
+					</div>
+				</CardHeader>
+				<CardContent>
+					<Skeleton className="h-16 w-full rounded-lg" />
+				</CardContent>
+			</Card>
+
 			<div className="flex justify-end pt-6">
 				<Skeleton className={isMobile ? "h-12 w-full rounded-lg" : "w-48 h-12 rounded-lg"} />
 			</div>
@@ -326,7 +404,7 @@ const Review = ({ defaultValues, setCurrentStep }: ReviewProps) => {
 						</div>
 						<div className="space-y-1">
 							<p className="text-sm font-medium text-muted-foreground">Gender</p>
-							<Badge variant="secondary">{defaultValues.gender}</Badge>
+							<p className="font-medium">{defaultValues.gender}</p>
 						</div>
 					</div>
 					<Separator />
@@ -357,9 +435,9 @@ const Review = ({ defaultValues, setCurrentStep }: ReviewProps) => {
 					<div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
 						<div className="space-y-1">
 							<p className="text-sm font-medium text-muted-foreground">Year</p>
-							<Badge variant="outline">
+							<p className="font-medium">
 								{reviewData.class.year.name} ({reviewData.class.year.code})
-							</Badge>
+							</p>
 						</div>
 						<div className="space-y-1">
 							<p className="text-sm font-medium text-muted-foreground">Branch</p>
@@ -369,7 +447,7 @@ const Review = ({ defaultValues, setCurrentStep }: ReviewProps) => {
 						</div>
 						<div className="space-y-1">
 							<p className="text-sm font-medium text-muted-foreground">Class</p>
-							<Badge variant="outline">{reviewData.class.code}</Badge>
+							<p className="font-medium">{reviewData.class.code}</p>
 						</div>
 					</div>
 				</CardContent>
@@ -401,14 +479,14 @@ const Review = ({ defaultValues, setCurrentStep }: ReviewProps) => {
 						</div>
 						<div className="space-y-1">
 							<p className="text-sm font-medium text-muted-foreground">Preferred Concession Class</p>
-							<Badge variant="outline">
+							<p className="font-medium">
 								{reviewData.concessionClass.name} ({reviewData.concessionClass.code})
-							</Badge>
+							</p>
 						</div>
 					</div>
 					<div className="space-y-1">
 						<p className="text-sm font-medium text-muted-foreground">Preferred Concession Period</p>
-						<Badge variant="outline">
+						<p className="font-medium">
 							{reviewData.concessionPeriod.name} (
 							{reviewData.concessionPeriod?.duration != null
 								? `${reviewData.concessionPeriod.duration} ${
@@ -416,7 +494,7 @@ const Review = ({ defaultValues, setCurrentStep }: ReviewProps) => {
 									}`
 								: "N/A"}
 							)
-						</Badge>
+						</p>
 					</div>
 				</CardContent>
 			</Card>


### PR DESCRIPTION
## Closes: #577 

## Type of change

- [ ] Chore
- [ ] Bug fix
- [ ] Refactor
- [x] New feature
- [ ] Performance
- [ ] Documentation
- [ ] Breaking change

## Summary
This pull request introduces a new admin action for generating sample overlay PDFs and significantly improves the admin UI for address change requests by adding an in-app document viewer for verification documents. Additionally, it adds a backend action to update booklet anchor coordinates with validation. The main changes are grouped below:

### New Features

* Added `generateSampleOverlayPDF` admin action, which creates a sample overlay PDF using form layout configuration and sample data, returning a base64-encoded PDF. This helps admins preview overlays before applying them.
* Added `updateBookletAnchorCoordinates` backend action to update `anchorX` and `anchorY` for a booklet, with validation and error handling.

### Admin UI Improvements for Address Change Requests

* Added an in-app document viewer for verification documents in the address change requests dialog. Admins can now view documents directly in a split-pane modal without leaving the app, improving workflow and UX. [[1]](diffhunk://#diff-2c0eb8187a29a3ea68d30afc681773a5105dd28b58be85fcb15b514ab6805b6cR102) [[2]](diffhunk://#diff-2c0eb8187a29a3ea68d30afc681773a5105dd28b58be85fcb15b514ab6805b6cL254-R272) [[3]](diffhunk://#diff-2c0eb8187a29a3ea68d30afc681773a5105dd28b58be85fcb15b514ab6805b6cL420-R446) [[4]](diffhunk://#diff-2c0eb8187a29a3ea68d30afc681773a5105dd28b58be85fcb15b514ab6805b6cL528-R576) [[5]](diffhunk://#diff-2c0eb8187a29a3ea68d30afc681773a5105dd28b58be85fcb15b514ab6805b6cR664-R690)
* The document viewer's open/close state is managed to reset appropriately on dialog close or after approve/reject actions, ensuring a consistent and bug-free experience. [[1]](diffhunk://#diff-2c0eb8187a29a3ea68d30afc681773a5105dd28b58be85fcb15b514ab6805b6cR158) [[2]](diffhunk://#diff-2c0eb8187a29a3ea68d30afc681773a5105dd28b58be85fcb15b514ab6805b6cR217) [[3]](diffhunk://#diff-2c0eb8187a29a3ea68d30afc681773a5105dd28b58be85fcb15b514ab6805b6cR246-R251)

### Minor

* Added the `X` icon import for use in the UI.

## Checklist

- [x] Issue linked
- [x] Documentation updated
- [x] No sensitive data committed
- [x] Prisma migration added (if schema changed)
