### PR TITLE
refactor(auth): replace session-based admin checks with requireAdmin utility in PDF generation actions

### DIFF
--- a/src/actions/generate-overlay-pdf.ts
+++ b/src/actions/generate-overlay-pdf.ts
@@ -4,7 +4,6 @@ import {
 	Result,
 	success,
 	failure,
-	authError,
 	AuthError,
 	databaseError,
 	DatabaseError,
@@ -13,9 +12,8 @@ import {
 } from "@/lib/result";
 import jsPDF from "jspdf";
 import prisma from "@/lib/prisma";
-import { auth } from "@/lib/auth";
-import { headers } from "next/headers";
 import { PDFDocument, degrees } from "pdf-lib";
+import { requireAdmin } from "@/lib/auth-guard";
 import { formatDateOfBirth, calcAgeFromDob } from "@/lib/utils";
 
 type FormLayout = {
@@ -52,38 +50,13 @@ const addMonths = (date: Date, months: number) => {
 	return d;
 };
 
-const calcAge = (dob: Date) => {
-	const today = new Date();
-	const birth = new Date(dob);
-	let years = today.getFullYear() - birth.getFullYear();
-	let months = today.getMonth() - birth.getMonth();
-	if (today.getDate() < birth.getDate()) months--;
-	if (months < 0) {
-		years--;
-		months += 12;
-	}
-	return { years, months };
-};
-
 export const generateOverlayPDF = async (
 	applicationId: string
 ): Promise<Result<Uint8Array, AuthError | DatabaseError | ValidationError>> => {
+	const adminResult = await requireAdmin();
+	if (!adminResult.isSuccess) return adminResult;
+
 	try {
-		const session = await auth.api.getSession({
-			headers: await headers()
-		});
-
-		if (!session?.user?.id) {
-			return failure(authError("Authentication required", "UNAUTHORIZED"));
-		}
-
-		const admin = await prisma.admin.findUnique({
-			where: { userId: session.user.id }
-		});
-
-		if (!admin) {
-			return failure(authError("Admin access required", "FORBIDDEN"));
-		}
 		const application = await prisma.concessionApplication.findUnique({
 			where: { id: applicationId },
 			include: {

--- a/src/actions/generate-sample-overlay-pdf.ts
+++ b/src/actions/generate-sample-overlay-pdf.ts
@@ -2,11 +2,10 @@
 
 import jsPDF from "jspdf";
 import prisma from "@/lib/prisma";
-import { auth } from "@/lib/auth";
-import { headers } from "next/headers";
 import { PDFDocument, degrees } from "pdf-lib";
+import { requireAdmin } from "@/lib/auth-guard";
 import { formatDateOfBirth, calcAgeFromDob } from "@/lib/utils";
-import { Result, success, failure, authError, AuthError, databaseError, DatabaseError } from "@/lib/result";
+import { Result, success, failure, AuthError, databaseError, DatabaseError } from "@/lib/result";
 
 type FormLayout = {
 	left: Record<string, { x: number; y: number }>;
@@ -42,19 +41,6 @@ const addMonths = (date: Date, months: number) => {
 	return d;
 };
 
-const calcAge = (dob: Date) => {
-	const today = new Date();
-	const birth = new Date(dob);
-	let years = today.getFullYear() - birth.getFullYear();
-	let months = today.getMonth() - birth.getMonth();
-	if (today.getDate() < birth.getDate()) months--;
-	if (months < 0) {
-		years--;
-		months += 12;
-	}
-	return { years, months };
-};
-
 const SAMPLE_DATA = {
 	gender: "Male",
 	classCode: "II",
@@ -76,23 +62,10 @@ export const generateSampleOverlayPDF = async (
 	anchorX: number,
 	anchorY: number
 ): Promise<Result<string, AuthError | DatabaseError>> => {
+	const adminResult = await requireAdmin();
+	if (!adminResult.isSuccess) return adminResult;
+
 	try {
-		const session = await auth.api.getSession({
-			headers: await headers()
-		});
-
-		if (!session?.user?.id) {
-			return failure(authError("Authentication required", "UNAUTHORIZED"));
-		}
-
-		const admin = await prisma.admin.findUnique({
-			where: { userId: session.user.id }
-		});
-
-		if (!admin) {
-			return failure(authError("Admin access required", "FORBIDDEN"));
-		}
-
 		const config = await prisma.appConfig.findUnique({
 			where: { key: "form_layout" }
 		});


### PR DESCRIPTION
## Type of change

- [ ] Chore
- [x] Bug fix
- [x] Refactor
- [ ] New feature
- [ ] Performance
- [ ] Documentation
- [ ] Breaking change

## Summary
This pull request refactors authentication and authorization logic in the PDF generation actions by replacing inline session checks with a reusable `requireAdmin` guard. It also removes redundant code and cleans up utility imports, making the codebase more maintainable and consistent.

**Authorization and Authentication Refactoring:**

* Replaced manual session and admin checks in `generateOverlayPDF` and `generateSampleOverlayPDF` with a call to the new `requireAdmin` function, centralizing admin authorization logic and simplifying the code. [[1]](diffhunk://#diff-4f7a0ff692274ba3513039c253320bd1f811fb63813c20fdf4994b72f513a540L16-R16) [[2]](diffhunk://#diff-4f7a0ff692274ba3513039c253320bd1f811fb63813c20fdf4994b72f513a540L55-R59) [[3]](diffhunk://#diff-fc469d5077ca449b5107958827dc5fd627a86606cf712c0897ce441e26d6a06fL5-R8) [[4]](diffhunk://#diff-fc469d5077ca449b5107958827dc5fd627a86606cf712c0897ce441e26d6a06fL79-R68)

**Code Cleanup and Utility Updates:**

* Removed unused `calcAge` function from both `generate-overlay-pdf.ts` and `generate-sample-overlay-pdf.ts`, as age calculation is now handled by `calcAgeFromDob` from `@/lib/utils`. [[1]](diffhunk://#diff-4f7a0ff692274ba3513039c253320bd1f811fb63813c20fdf4994b72f513a540L55-R59) [[2]](diffhunk://#diff-fc469d5077ca449b5107958827dc5fd627a86606cf712c0897ce441e26d6a06fL45-L57)
* Cleaned up imports by removing unused authentication and header imports, and unnecessary error exports from `@/lib/result`. [[1]](diffhunk://#diff-4f7a0ff692274ba3513039c253320bd1f811fb63813c20fdf4994b72f513a540L7) [[2]](diffhunk://#diff-fc469d5077ca449b5107958827dc5fd627a86606cf712c0897ce441e26d6a06fL5-R8)

## Checklist

- [ ] Issue linked
- [x] Documentation updated
- [x] No sensitive data committed
- [x] Prisma migration added (if schema changed)
