### PR TITLE
chore: add optional issuer field to Account model and table

### DIFF
--- a/prisma/migrations/20260831152513_add_issuer_field_to_accounts/migration.sql
+++ b/prisma/migrations/20260831152513_add_issuer_field_to_accounts/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Account" ADD COLUMN     "issuer" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,10 +53,11 @@ model Session {
 }
 
 model Account {
-  id         String @id
+  id         String  @id
   userId     String
   accountId  String
   providerId String
+  issuer     String?
 
   scope    String?
   password String?


### PR DESCRIPTION
## Type of change

- [x] Chore
- [ ] Bug fix
- [ ] Refactor
- [ ] New feature
- [ ] Performance
- [ ] Documentation
- [ ] Breaking change

## Summary
This pull request adds support for an optional `issuer` field to the `Account` model. The main changes include updating the database schema and the Prisma model to include this new field.

**Database schema update:**

* Added a new nullable `issuer` column of type `TEXT` to the `Account` table.

**Prisma schema update:**

* Added an optional `issuer` field of type `String?` to the `Account` model in `schema.prisma`.

## Checklist

- [ ] Issue linked
- [x] Documentation updated
- [x] No sensitive data committed
- [x] Prisma migration added (if schema changed)
